### PR TITLE
調整 KnowledgeBase 的 Files API 範例

### DIFF
--- a/python/knowledges/manage_knowledge_base_files.py
+++ b/python/knowledges/manage_knowledge_base_files.py
@@ -48,16 +48,27 @@ def main():
         if file_list and len(file_list) > 0:
             file_id = file_list[0].get('id')
             print(f"\n3. 更新檔案元數據 (ID: {file_id})...")
+
+            # 先獲取知識庫的標籤列表
+            labels_response = maiagent_helper.list_knowledge_base_labels(KNOWLEDGE_BASE_ID)
+            labels_list = labels_response.get('results', [])
+
+            # 如果有標籤，使用第一個標籤；否則不設定標籤
+            labels_to_set = [{"id": labels_list[0]['id']}] if labels_list else None
+
             updated_file = maiagent_helper.update_knowledge_base_file_metadata(
                 knowledge_base_id=KNOWLEDGE_BASE_ID,
                 file_id=file_id,
-                labels=[{"id": "label-id", "name": "重要文件"}],
-                metadata={"category": "documentation", "priority": "high"}
+                labels=labels_to_set,
+                raw_user_define_metadata={"category": "documentation", "priority": "high"}
             )
             print("檔案元數據更新成功")
+            if labels_to_set:
+                print(f"  已設定標籤: {updated_file.get('labels', [])}")
+            print(f"  已設定自定義元數據: {updated_file.get('rawUserDefineMetadata', {})}")
         
         # 4. 批次操作範例
-        print("\n4. 批次操作範例...")
+        #print("\n4. 批次操作範例...")
         
         # 批次刪除檔案 (可選，取消註解以執行)
         # if file_list and len(file_list) > 0:

--- a/python/utils/maiagent.py
+++ b/python/utils/maiagent.py
@@ -608,19 +608,19 @@ class MaiAgentHelper:
             print(e)
             exit(1)
 
-    def update_knowledge_base_file_metadata(self, knowledge_base_id, file_id, labels=None, metadata=None):
+    def update_knowledge_base_file_metadata(self, knowledge_base_id, file_id, labels=None, raw_user_define_metadata=None):
         """更新知識庫檔案的標籤和元數據"""
         url = f'{self.base_url}knowledge-bases/{knowledge_base_id}/files/{file_id}/update-metadata/'
-        
+
         headers = {
             'Authorization': f'Api-Key {self.api_key}',
         }
-        
+
         payload = {}
         if labels is not None:
             payload['labels'] = labels
-        if metadata is not None:
-            payload['metadata'] = metadata
+        if raw_user_define_metadata is not None:
+            payload['rawUserDefineMetadata'] = raw_user_define_metadata
         
         try:
             response = requests.patch(url, headers=headers, json=payload)
@@ -817,19 +817,19 @@ class MaiAgentHelper:
             print(e)
             exit(1)
 
-    def update_knowledge_base_faq_metadata(self, knowledge_base_id, faq_id, labels=None, metadata=None):
+    def update_knowledge_base_faq_metadata(self, knowledge_base_id, faq_id, labels=None, raw_user_define_metadata=None):
         """更新知識庫 FAQ 的標籤和元數據"""
         url = f'{self.base_url}knowledge-bases/{knowledge_base_id}/faqs/{faq_id}/update-metadata/'
-        
+
         headers = {
             'Authorization': f'Api-Key {self.api_key}',
         }
-        
+
         payload = {}
         if labels is not None:
             payload['labels'] = labels
-        if metadata is not None:
-            payload['metadata'] = metadata
+        if raw_user_define_metadata is not None:
+            payload['rawUserDefineMetadata'] = raw_user_define_metadata
         
         try:
             response = requests.patch(url, headers=headers, json=payload)


### PR DESCRIPTION
https://app.asana.com/1/1202280977140605/project/1210715058345905/task/1211207195284546?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace metadata with rawUserDefineMetadata in helper methods and update the files example to fetch labels dynamically and print applied metadata.
> 
> - **Backend helpers (`python/utils/maiagent.py`)**:
>   - Update `update_knowledge_base_file_metadata` and `update_knowledge_base_faq_metadata` to accept `raw_user_define_metadata` and send `rawUserDefineMetadata` in payload (replacing `metadata`).
> - **Example script (`python/knowledges/manage_knowledge_base_files.py`)**:
>   - Fetch knowledge base labels via `list_knowledge_base_labels` and, if available, set the first label when updating a file.
>   - Use `raw_user_define_metadata` with metadata example payload when calling `update_knowledge_base_file_metadata` and print returned labels and `rawUserDefineMetadata`.
>   - Comment out the batch operations section header print.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 676a91a63796fb8cf01f36373e9f208f7834985c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->