### PR TITLE
fix: S3/MinIO 上傳 URL 改從 API response 取得，並修正 form data 順序

### DIFF
--- a/examples/csharp/messages/chatbot_completion.cs
+++ b/examples/csharp/messages/chatbot_completion.cs
@@ -36,7 +36,8 @@ namespace MaiAgentExamples.Messages
         // 獲取 MaiAgent 幫助器實例
         private static MaiAgentHelper GetMaiAgentHelper()
         {
-            return new MaiAgentHelper(Config.API_KEY, Config.BASE_URL, Config.STORAGE_URL);
+            // storageUrl 不再需要，上傳 URL 會從 API response 自動取得
+            return new MaiAgentHelper(Config.API_KEY, Config.BASE_URL);
         }
 
         // 打印分隔線和標題

--- a/examples/python/messages/chatbot_completion.py
+++ b/examples/python/messages/chatbot_completion.py
@@ -1,5 +1,5 @@
 from utils import MaiAgentHelper
-from utils.config import API_KEY, BASE_URL, CHATBOT_ID, STORAGE_URL
+from utils.config import API_KEY, BASE_URL, CHATBOT_ID
 import sys
 import os
 
@@ -28,10 +28,10 @@ SEPARATOR_LINE = "=" * 50
 
 def get_maiagent_helper() -> MaiAgentHelper:
     """獲取 MaiAgent 幫助器實例"""
+    # storage_url 不再需要，上傳 URL 會從 API response 自動取得
     return MaiAgentHelper(
         api_key=API_KEY,
-        base_url=BASE_URL,
-        storage_url=STORAGE_URL
+        base_url=BASE_URL
     )
 
 def print_separator(title: str):


### PR DESCRIPTION
## Summary
- 移除 `storageUrl` 參數，改從 presigned URL API response 取得上傳 URL
- 修正 multipart form data 順序，確保 file 欄位在最後（S3/MinIO 要求）
- C# 和 Python 版本行為一致

## 問題背景
客戶在地端部署時，使用 MinIO 會收到 BadRequest 錯誤：
1. `storageUrl` 是寫死的，需要客戶手動設定
2. form data 順序不正確，file 不在最後

## 修改檔案
| 語言 | 檔案 | 改動 |
|------|------|------|
| C# | `utils/maiagent.cs` | 移除 storageUrl，URL 從 response 取得，file 放最後 |
| C# | `messages/chatbot_completion.cs` | 呼叫改成 2 參數 |
| Python | `utils/maiagent.py` | 移除 storage_url，URL 從 response 取得，明確控制順序 |

## Test plan
- [x] C# DEV 環境測試通過
- [x] Python DEV 環境測試通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **S3/MinIO uploads now use presigned URLs from API responses** and enforce correct multipart ordering.
> 
> - Remove `storageUrl` param from `MaiAgentHelper` (C# and Python); constructors and example usages updated
> - `upload_file_to_s3`/`UploadFileToS3Async` now read `url` from presigned response and post to it
> - Enforce multipart form order: add all `fields` first and `file` last (required by S3/MinIO)
> - Example scripts (`chatbot_completion` in C# and Python) adjusted to new helper signatures and consistent behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22ea342957a82e95faac71995285c99099f9b8d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212834214889616
  - https://app.asana.com/0/0/1212807711690455