### PR TITLE
docs: 新增 Contacts API 文件說明與範例

### DIFF
--- a/examples/csharp/README.md
+++ b/examples/csharp/README.md
@@ -11,6 +11,7 @@
   - [send_image_message.cs](messages/send_image_message.cs): 發送圖片訊息範例
   - [webhook_server.cs](messages/webhook_server.cs): Webhook 伺服器範例
 - [knowledges](knowledges/): 管理知識庫的範例
+- [contacts](contacts/): 管理聯絡人的範例
 - [faqs](faqs/): 管理常見問題的範例
 - [batch_qa](batch_qa/): 發送批次問答的範例
 - [others](others/): 其他有用的範例
@@ -145,6 +146,13 @@ csharp/
 │       ├── delete_duplicate_files.cs
 │       ├── fix_failed_files.cs
 │       └── upload_missing_files.cs
+├── contacts/                          # 聯絡人管理範例
+│   ├── list_contacts.cs
+│   ├── create_contact.cs
+│   ├── update_contact.cs
+│   ├── delete_contact.cs
+│   ├── get_contact_conversations.cs
+│   └── broadcast_message.cs
 ├── faqs/                              # FAQ 管理範例
 │   └── add_faq.cs
 ├── assistants/                        # 助手管理範例

--- a/examples/csharp/contacts/README.md
+++ b/examples/csharp/contacts/README.md
@@ -1,0 +1,60 @@
+# Contacts API 使用說明
+
+管理聯絡人（Contacts）的 API 範例，包含聯絡人的 CRUD 操作、查詢對話紀錄、群發訊息等功能。
+
+## API 端點總覽
+
+| 操作 | 方法 | 端點 | 說明 |
+|------|------|------|------|
+| 列出聯絡人 | GET | `/api/v1/contacts/` | 取得聯絡人清單（支援篩選、搜尋） |
+| 建立聯絡人 | POST | `/api/v1/contacts/` | 建立新的聯絡人 |
+| 取得聯絡人 | GET | `/api/v1/contacts/{id}/` | 取得單一聯絡人詳細資訊 |
+| 更新聯絡人 | PATCH | `/api/v1/contacts/{id}/` | 更新聯絡人資訊 |
+| 刪除聯絡人 | DELETE | `/api/v1/contacts/{id}/` | 刪除聯絡人（軟刪除） |
+| 查詢對話 | GET | `/api/v1/contacts/{id}/conversations` | 取得聯絡人的對話紀錄 |
+| 最新對話 | GET | `/api/v1/contacts/{id}/conversations/latest` | 取得聯絡人最新的對話 |
+| 群發訊息 | POST | `/api/v1/contacts/broadcast-message` | 對多個聯絡人群發訊息 |
+
+## 聯絡人欄位說明
+
+| 欄位 | 類型 | 必填 | 說明 |
+|------|------|------|------|
+| `id` | UUID | 自動產生 | 聯絡人唯一識別碼 |
+| `name` | string | 是 | 聯絡人名稱 |
+| `email` | string | 否 | 電子信箱 |
+| `phone_number` | string | 否 | 電話號碼 |
+| `avatar` | URL | 否 | 頭像網址 |
+| `source_id` | string | 否 | 外部來源識別碼（同一 inbox 內不可重複） |
+| `inboxes` | array | 是 | 所屬的 inbox 列表，格式：`[{"id": "inbox-uuid"}]` |
+| `query_metadata` | object | 否 | 自訂的查詢用 metadata（JSON 格式） |
+| `mcp_credentials` | array | 唯讀 | MCP 憑證列表 |
+| `created_at` | datetime | 自動產生 | 建立時間 |
+| `updated_at` | datetime | 自動產生 | 更新時間 |
+
+## 篩選參數
+
+列出聯絡人時可使用以下查詢參數：
+
+| 參數 | 說明 |
+|------|------|
+| `query` | 依聯絡人 ID、名稱或 source_id 搜尋（模糊比對） |
+| `inboxes` | 依 inbox ID 篩選 |
+| `limit` | 每頁筆數（預設 20） |
+| `offset` | 分頁偏移量 |
+
+## 範例檔案
+
+- [list_contacts.cs](list_contacts.cs): 列出聯絡人清單（含篩選）
+- [create_contact.cs](create_contact.cs): 建立新聯絡人
+- [update_contact.cs](update_contact.cs): 更新聯絡人資訊
+- [delete_contact.cs](delete_contact.cs): 刪除聯絡人
+- [get_contact_conversations.cs](get_contact_conversations.cs): 取得聯絡人對話紀錄
+- [broadcast_message.cs](broadcast_message.cs): 群發訊息給多個聯絡人
+
+## 群發訊息模式
+
+`broadcast-message` 支援三種模式：
+
+1. **指定聯絡人**：提供 `contact_ids` 列表，僅發送給指定的聯絡人
+2. **排除聯絡人**：提供 `inbox_id` + `exclude_contact_ids`，發送給該 inbox 中排除指定聯絡人以外的所有人
+3. **全部發送**：僅提供 `inbox_id`，發送給該 inbox 的所有聯絡人

--- a/examples/csharp/contacts/broadcast_message.cs
+++ b/examples/csharp/contacts/broadcast_message.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace MaiAgentExamples.Contacts
+{
+    public static class BroadcastMessage
+    {
+        public static string API_KEY = "<your-api-key>";
+        public static string BASE_URL = "https://api.maiagent.ai/api/v1/";
+
+        public static async Task Main(string[] args)
+        {
+            Debug.Assert(API_KEY != "<your-api-key>", "Please set your API key");
+
+            using var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Add("Authorization", $"Api-Key {API_KEY}");
+
+            // ===== 模式 1：指定聯絡人 ID 群發 =====
+            var payload = new
+            {
+                message = "您好，這是一則群發訊息！",
+                contact_ids = new[]
+                {
+                    "<contact-id-1>",
+                    "<contact-id-2>",
+                    "<contact-id-3>",
+                },
+            };
+
+            var content = new StringContent(
+                JsonSerializer.Serialize(payload),
+                Encoding.UTF8,
+                "application/json");
+
+            var response = await httpClient.PostAsync($"{BASE_URL}contacts/broadcast-message", content);
+            response.EnsureSuccessStatusCode();
+
+            var responseString = await response.Content.ReadAsStringAsync();
+            var result = JsonSerializer.Deserialize<JsonElement>(responseString);
+
+            Console.WriteLine("群發結果：");
+            Console.WriteLine($"  總共: {result.GetProperty("total_contacts")} 人");
+            Console.WriteLine($"  成功: {result.GetProperty("success_count")} 人");
+            Console.WriteLine($"  失敗: {result.GetProperty("error_count")} 人");
+
+            foreach (var item in result.GetProperty("results").EnumerateArray())
+            {
+                Console.WriteLine($"  ✓ contact: {item.GetProperty("contact_id")}, message: {item.GetProperty("message_id")}");
+            }
+
+            foreach (var error in result.GetProperty("errors").EnumerateArray())
+            {
+                Console.WriteLine($"  ✗ contact: {error.GetProperty("contact_id")}, error: {error.GetProperty("error")}");
+            }
+
+            // ===== 模式 2：指定 inbox，排除特定聯絡人 =====
+            // var payload2 = new
+            // {
+            //     message = "您好，這是一則群發訊息！",
+            //     inbox_id = "<inbox-id>",
+            //     exclude_contact_ids = new[] { "<contact-id-to-exclude>" },
+            // };
+
+            // ===== 模式 3：對整個 inbox 所有聯絡人群發 =====
+            // var payload3 = new
+            // {
+            //     message = "您好，這是一則群發訊息！",
+            //     inbox_id = "<inbox-id>",
+            // };
+
+            /*
+            回應格式：
+            {
+                "results": [
+                    {
+                        "contact_id": "uuid",
+                        "conversation_id": "uuid",
+                        "message_id": "uuid",
+                        "status": "success"
+                    }
+                ],
+                "errors": [
+                    {
+                        "contact_id": "uuid",
+                        "error": "No conversation found for this contact."
+                    }
+                ],
+                "total_contacts": 3,
+                "success_count": 2,
+                "error_count": 1
+            }
+            */
+        }
+    }
+}

--- a/examples/csharp/contacts/create_contact.cs
+++ b/examples/csharp/contacts/create_contact.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace MaiAgentExamples.Contacts
+{
+    public static class CreateContact
+    {
+        public static string API_KEY = "<your-api-key>";
+        public static string BASE_URL = "https://api.maiagent.ai/api/v1/";
+
+        // 聯絡人所屬的 inbox ID（必填）
+        public static string INBOX_ID = "<your-inbox-id>";
+
+        public static async Task Main(string[] args)
+        {
+            Debug.Assert(API_KEY != "<your-api-key>", "Please set your API key");
+            Debug.Assert(INBOX_ID != "<your-inbox-id>", "Please set your inbox id");
+
+            using var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Add("Authorization", $"Api-Key {API_KEY}");
+
+            // 建立聯絡人
+            var payload = new
+            {
+                name = "John Doe",
+                email = "john@example.com",
+                phone_number = "+886912345678",
+                inboxes = new[] { new { id = INBOX_ID } },
+                // 選填欄位
+                // avatar = "https://example.com/avatar.jpg",
+                // source_id = "external_id_123",
+                // query_metadata = new { source = "web", campaign = "spring_2024" },
+            };
+
+            var content = new StringContent(
+                JsonSerializer.Serialize(payload),
+                Encoding.UTF8,
+                "application/json");
+
+            var response = await httpClient.PostAsync($"{BASE_URL}contacts/", content);
+            response.EnsureSuccessStatusCode();
+
+            var responseString = await response.Content.ReadAsStringAsync();
+            var contact = JsonSerializer.Deserialize<JsonElement>(responseString);
+
+            Console.WriteLine("聯絡人建立成功！");
+            Console.WriteLine($"  ID: {contact.GetProperty("id")}");
+            Console.WriteLine($"  名稱: {contact.GetProperty("name")}");
+
+            var email = contact.TryGetProperty("email", out var emailProp) && emailProp.ValueKind != JsonValueKind.Null
+                ? emailProp.GetString() : "N/A";
+            Console.WriteLine($"  Email: {email}");
+
+            /*
+            回應格式：
+            {
+                "id": "contact-uuid",
+                "name": "John Doe",
+                "email": "john@example.com",
+                "phone_number": "+886912345678",
+                "avatar": null,
+                "source_id": null,
+                "inboxes": [
+                    {"id": "inbox-uuid", "name": "My Inbox"}
+                ],
+                "query_metadata": null,
+                "mcp_credentials": [],
+                "created_at": "2024-01-01T00:00:00Z",
+                "updated_at": "2024-01-01T00:00:00Z"
+            }
+            */
+        }
+    }
+}

--- a/examples/csharp/contacts/delete_contact.cs
+++ b/examples/csharp/contacts/delete_contact.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace MaiAgentExamples.Contacts
+{
+    public static class DeleteContact
+    {
+        public static string API_KEY = "<your-api-key>";
+        public static string BASE_URL = "https://api.maiagent.ai/api/v1/";
+
+        public static string CONTACT_ID = "<your-contact-id>";
+
+        public static async Task Main(string[] args)
+        {
+            Debug.Assert(API_KEY != "<your-api-key>", "Please set your API key");
+            Debug.Assert(CONTACT_ID != "<your-contact-id>", "Please set your contact id");
+
+            using var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Add("Authorization", $"Api-Key {API_KEY}");
+
+            // 刪除聯絡人（軟刪除）
+            var response = await httpClient.DeleteAsync($"{BASE_URL}contacts/{CONTACT_ID}/");
+            response.EnsureSuccessStatusCode();
+
+            Console.WriteLine($"聯絡人 {CONTACT_ID} 已刪除");
+        }
+    }
+}

--- a/examples/csharp/contacts/get_contact_conversations.cs
+++ b/examples/csharp/contacts/get_contact_conversations.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace MaiAgentExamples.Contacts
+{
+    public static class GetContactConversations
+    {
+        public static string API_KEY = "<your-api-key>";
+        public static string BASE_URL = "https://api.maiagent.ai/api/v1/";
+
+        public static string CONTACT_ID = "<your-contact-id>";
+
+        public static async Task Main(string[] args)
+        {
+            Debug.Assert(API_KEY != "<your-api-key>", "Please set your API key");
+            Debug.Assert(CONTACT_ID != "<your-contact-id>", "Please set your contact id");
+
+            using var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Add("Authorization", $"Api-Key {API_KEY}");
+
+            // 取得聯絡人的所有對話
+            var response = await httpClient.GetAsync($"{BASE_URL}contacts/{CONTACT_ID}/conversations");
+            response.EnsureSuccessStatusCode();
+
+            var responseString = await response.Content.ReadAsStringAsync();
+            var data = JsonSerializer.Deserialize<JsonElement>(responseString);
+
+            Console.WriteLine($"共 {data.GetProperty("count")} 筆對話");
+            foreach (var conversation in data.GetProperty("results").EnumerateArray())
+            {
+                Console.WriteLine($"  - 對話 ID: {conversation.GetProperty("id")}");
+            }
+
+            // 也可以用關鍵字搜尋對話中的訊息
+            var searchResponse = await httpClient.GetAsync(
+                $"{BASE_URL}contacts/{CONTACT_ID}/conversations?keyword=你好");
+            searchResponse.EnsureSuccessStatusCode();
+
+            var searchString = await searchResponse.Content.ReadAsStringAsync();
+            var searchData = JsonSerializer.Deserialize<JsonElement>(searchString);
+
+            Console.WriteLine($"\n搜尋結果：共 {searchData.GetProperty("count")} 筆對話");
+
+            // 取得最新的一筆對話
+            var latestResponse = await httpClient.GetAsync(
+                $"{BASE_URL}contacts/{CONTACT_ID}/conversations/latest");
+
+            if (latestResponse.IsSuccessStatusCode)
+            {
+                var latestString = await latestResponse.Content.ReadAsStringAsync();
+                var latest = JsonSerializer.Deserialize<JsonElement>(latestString);
+                Console.WriteLine($"\n最新對話 ID: {latest.GetProperty("id")}");
+            }
+            else if ((int)latestResponse.StatusCode == 404)
+            {
+                Console.WriteLine("\n該聯絡人尚無對話紀錄");
+            }
+        }
+    }
+}

--- a/examples/csharp/contacts/list_contacts.cs
+++ b/examples/csharp/contacts/list_contacts.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace MaiAgentExamples.Contacts
+{
+    public static class ListContacts
+    {
+        public static string API_KEY = "<your-api-key>";
+        public static string BASE_URL = "https://api.maiagent.ai/api/v1/";
+
+        public static async Task Main(string[] args)
+        {
+            Debug.Assert(API_KEY != "<your-api-key>", "Please set your API key");
+
+            using var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Add("Authorization", $"Api-Key {API_KEY}");
+
+            // 列出所有聯絡人
+            var response = await httpClient.GetAsync($"{BASE_URL}contacts/");
+            response.EnsureSuccessStatusCode();
+
+            var responseString = await response.Content.ReadAsStringAsync();
+            var data = JsonSerializer.Deserialize<JsonElement>(responseString);
+
+            Console.WriteLine($"共 {data.GetProperty("count")} 筆聯絡人");
+            foreach (var contact in data.GetProperty("results").EnumerateArray())
+            {
+                Console.WriteLine($"  - {contact.GetProperty("name")} (ID: {contact.GetProperty("id")})");
+            }
+
+            // 使用篩選參數查詢
+            // query: 依名稱、ID 或 source_id 搜尋（模糊比對）
+            // inboxes: 依 inbox ID 篩選
+            var searchResponse = await httpClient.GetAsync($"{BASE_URL}contacts/?query=John&limit=10&offset=0");
+            searchResponse.EnsureSuccessStatusCode();
+
+            var searchString = await searchResponse.Content.ReadAsStringAsync();
+            var searchData = JsonSerializer.Deserialize<JsonElement>(searchString);
+
+            Console.WriteLine($"\n搜尋結果：共 {searchData.GetProperty("count")} 筆");
+            foreach (var contact in searchData.GetProperty("results").EnumerateArray())
+            {
+                var email = contact.TryGetProperty("email", out var emailProp) && emailProp.ValueKind != JsonValueKind.Null
+                    ? emailProp.GetString() : "N/A";
+                Console.WriteLine($"  - {contact.GetProperty("name")} (email: {email})");
+            }
+
+            /*
+            回應格式：
+            {
+                "count": 100,
+                "next": "https://api.maiagent.ai/api/v1/contacts/?limit=20&offset=20",
+                "previous": null,
+                "results": [
+                    {
+                        "id": "contact-uuid",
+                        "name": "John Doe",
+                        "email": "john@example.com",
+                        "phone_number": "+886912345678",
+                        "avatar": "https://example.com/avatar.jpg",
+                        "source_id": "external_id_123",
+                        "inboxes": [
+                            {"id": "inbox-uuid", "name": "My Inbox"}
+                        ],
+                        "query_metadata": {"source": "web"},
+                        "mcp_credentials": [],
+                        "created_at": "2024-01-01T00:00:00Z",
+                        "updated_at": "2024-01-01T00:00:00Z"
+                    }
+                ]
+            }
+            */
+        }
+    }
+}

--- a/examples/csharp/contacts/update_contact.cs
+++ b/examples/csharp/contacts/update_contact.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace MaiAgentExamples.Contacts
+{
+    public static class UpdateContact
+    {
+        public static string API_KEY = "<your-api-key>";
+        public static string BASE_URL = "https://api.maiagent.ai/api/v1/";
+
+        public static string CONTACT_ID = "<your-contact-id>";
+
+        public static async Task Main(string[] args)
+        {
+            Debug.Assert(API_KEY != "<your-api-key>", "Please set your API key");
+            Debug.Assert(CONTACT_ID != "<your-contact-id>", "Please set your contact id");
+
+            using var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Add("Authorization", $"Api-Key {API_KEY}");
+
+            // 使用 PATCH 更新部分欄位
+            var payload = new
+            {
+                name = "John Doe (Updated)",
+                email = "john.updated@example.com",
+            };
+
+            var content = new StringContent(
+                JsonSerializer.Serialize(payload),
+                Encoding.UTF8,
+                "application/json");
+
+            var request = new HttpRequestMessage(HttpMethod.Patch, $"{BASE_URL}contacts/{CONTACT_ID}/")
+            {
+                Content = content
+            };
+
+            var response = await httpClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+
+            var responseString = await response.Content.ReadAsStringAsync();
+            var contact = JsonSerializer.Deserialize<JsonElement>(responseString);
+
+            Console.WriteLine("聯絡人更新成功！");
+            Console.WriteLine($"  ID: {contact.GetProperty("id")}");
+            Console.WriteLine($"  名稱: {contact.GetProperty("name")}");
+
+            var email = contact.TryGetProperty("email", out var emailProp) && emailProp.ValueKind != JsonValueKind.Null
+                ? emailProp.GetString() : "N/A";
+            Console.WriteLine($"  Email: {email}");
+        }
+    }
+}

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -11,6 +11,7 @@
   - send_image_message.py: 發送圖片訊息範例
   - webhook_server.py: Webhook 伺服器範例
 - [knowledges](knowledges/): 管理知識庫的範例
+- [contacts](contacts/): 管理聯絡人的範例
 - [faqs](faqs/): 管理常見問題的範例
 - [batch_qa](batch_qa/): 發送批次問答的範例
 - [others](others/): 其他有用的範例

--- a/examples/python/contacts/README.md
+++ b/examples/python/contacts/README.md
@@ -1,0 +1,60 @@
+# Contacts API 使用說明
+
+管理聯絡人（Contacts）的 API 範例，包含聯絡人的 CRUD 操作、查詢對話紀錄、群發訊息等功能。
+
+## API 端點總覽
+
+| 操作 | 方法 | 端點 | 說明 |
+|------|------|------|------|
+| 列出聯絡人 | GET | `/api/v1/contacts/` | 取得聯絡人清單（支援篩選、搜尋） |
+| 建立聯絡人 | POST | `/api/v1/contacts/` | 建立新的聯絡人 |
+| 取得聯絡人 | GET | `/api/v1/contacts/{id}/` | 取得單一聯絡人詳細資訊 |
+| 更新聯絡人 | PATCH | `/api/v1/contacts/{id}/` | 更新聯絡人資訊 |
+| 刪除聯絡人 | DELETE | `/api/v1/contacts/{id}/` | 刪除聯絡人（軟刪除） |
+| 查詢對話 | GET | `/api/v1/contacts/{id}/conversations` | 取得聯絡人的對話紀錄 |
+| 最新對話 | GET | `/api/v1/contacts/{id}/conversations/latest` | 取得聯絡人最新的對話 |
+| 群發訊息 | POST | `/api/v1/contacts/broadcast-message` | 對多個聯絡人群發訊息 |
+
+## 聯絡人欄位說明
+
+| 欄位 | 類型 | 必填 | 說明 |
+|------|------|------|------|
+| `id` | UUID | 自動產生 | 聯絡人唯一識別碼 |
+| `name` | string | 是 | 聯絡人名稱 |
+| `email` | string | 否 | 電子信箱 |
+| `phone_number` | string | 否 | 電話號碼 |
+| `avatar` | URL | 否 | 頭像網址 |
+| `source_id` | string | 否 | 外部來源識別碼（同一 inbox 內不可重複） |
+| `inboxes` | array | 是 | 所屬的 inbox 列表，格式：`[{"id": "inbox-uuid"}]` |
+| `query_metadata` | object | 否 | 自訂的查詢用 metadata（JSON 格式） |
+| `mcp_credentials` | array | 唯讀 | MCP 憑證列表 |
+| `created_at` | datetime | 自動產生 | 建立時間 |
+| `updated_at` | datetime | 自動產生 | 更新時間 |
+
+## 篩選參數
+
+列出聯絡人時可使用以下查詢參數：
+
+| 參數 | 說明 |
+|------|------|
+| `query` | 依聯絡人 ID、名稱或 source_id 搜尋（模糊比對） |
+| `inboxes` | 依 inbox ID 篩選 |
+| `limit` | 每頁筆數（預設 20） |
+| `offset` | 分頁偏移量 |
+
+## 範例檔案
+
+- [list_contacts.py](list_contacts.py): 列出聯絡人清單（含篩選）
+- [create_contact.py](create_contact.py): 建立新聯絡人
+- [update_contact.py](update_contact.py): 更新聯絡人資訊
+- [delete_contact.py](delete_contact.py): 刪除聯絡人
+- [get_contact_conversations.py](get_contact_conversations.py): 取得聯絡人對話紀錄
+- [broadcast_message.py](broadcast_message.py): 群發訊息給多個聯絡人
+
+## 群發訊息模式
+
+`broadcast-message` 支援三種模式：
+
+1. **指定聯絡人**：提供 `contact_ids` 列表，僅發送給指定的聯絡人
+2. **排除聯絡人**：提供 `inbox_id` + `exclude_contact_ids`，發送給該 inbox 中排除指定聯絡人以外的所有人
+3. **全部發送**：僅提供 `inbox_id`，發送給該 inbox 的所有聯絡人

--- a/examples/python/contacts/broadcast_message.py
+++ b/examples/python/contacts/broadcast_message.py
@@ -1,0 +1,79 @@
+import requests
+
+API_KEY = '<your-api-key>'
+BASE_URL = 'https://api.maiagent.ai/api/v1/'
+
+assert API_KEY != '<your-api-key>', 'Please set your API key'
+
+
+def main():
+    headers = {'Authorization': f'Api-Key {API_KEY}'}
+
+    # ===== 模式 1：指定聯絡人 ID 群發 =====
+    payload = {
+        'message': '您好，這是一則群發訊息！',
+        'contact_ids': [
+            '<contact-id-1>',
+            '<contact-id-2>',
+            '<contact-id-3>',
+        ],
+    }
+
+    response = requests.post(
+        url=f'{BASE_URL}contacts/broadcast-message',
+        headers=headers,
+        json=payload,
+    )
+    response.raise_for_status()
+    result = response.json()
+
+    print(f"群發結果：")
+    print(f"  總共: {result['total_contacts']} 人")
+    print(f"  成功: {result['success_count']} 人")
+    print(f"  失敗: {result['error_count']} 人")
+
+    for item in result['results']:
+        print(f"  ✓ contact: {item['contact_id']}, message: {item['message_id']}")
+
+    for error in result['errors']:
+        print(f"  ✗ contact: {error['contact_id']}, error: {error['error']}")
+
+    # ===== 模式 2：指定 inbox，排除特定聯絡人 =====
+    # payload = {
+    #     'message': '您好，這是一則群發訊息！',
+    #     'inbox_id': '<inbox-id>',
+    #     'exclude_contact_ids': ['<contact-id-to-exclude>'],
+    # }
+
+    # ===== 模式 3：對整個 inbox 所有聯絡人群發 =====
+    # payload = {
+    #     'message': '您好，這是一則群發訊息！',
+    #     'inbox_id': '<inbox-id>',
+    # }
+
+    """
+    回應格式：
+    {
+        "results": [
+            {
+                "contact_id": "uuid",
+                "conversation_id": "uuid",
+                "message_id": "uuid",
+                "status": "success"
+            }
+        ],
+        "errors": [
+            {
+                "contact_id": "uuid",
+                "error": "No conversation found for this contact."
+            }
+        ],
+        "total_contacts": 3,
+        "success_count": 2,
+        "error_count": 1
+    }
+    """
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/python/contacts/create_contact.py
+++ b/examples/python/contacts/create_contact.py
@@ -1,0 +1,63 @@
+import requests
+
+API_KEY = '<your-api-key>'
+BASE_URL = 'https://api.maiagent.ai/api/v1/'
+
+# 聯絡人所屬的 inbox ID（必填）
+INBOX_ID = '<your-inbox-id>'
+
+assert API_KEY != '<your-api-key>', 'Please set your API key'
+assert INBOX_ID != '<your-inbox-id>', 'Please set your inbox id'
+
+
+def main():
+    headers = {'Authorization': f'Api-Key {API_KEY}'}
+
+    # 建立聯絡人
+    payload = {
+        'name': 'John Doe',
+        'email': 'john@example.com',
+        'phone_number': '+886912345678',
+        'inboxes': [{'id': INBOX_ID}],
+        # 選填欄位
+        # 'avatar': 'https://example.com/avatar.jpg',
+        # 'source_id': 'external_id_123',
+        # 'query_metadata': {'source': 'web', 'campaign': 'spring_2024'},
+    }
+
+    response = requests.post(
+        url=f'{BASE_URL}contacts/',
+        headers=headers,
+        json=payload,
+    )
+    response.raise_for_status()
+    contact = response.json()
+
+    print(f"聯絡人建立成功！")
+    print(f"  ID: {contact['id']}")
+    print(f"  名稱: {contact['name']}")
+    print(f"  Email: {contact.get('email', 'N/A')}")
+    print(f"  Inboxes: {[inbox['name'] for inbox in contact['inboxes']]}")
+
+    """
+    回應格式：
+    {
+        "id": "contact-uuid",
+        "name": "John Doe",
+        "email": "john@example.com",
+        "phone_number": "+886912345678",
+        "avatar": null,
+        "source_id": null,
+        "inboxes": [
+            {"id": "inbox-uuid", "name": "My Inbox"}
+        ],
+        "query_metadata": null,
+        "mcp_credentials": [],
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-01T00:00:00Z"
+    }
+    """
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/python/contacts/delete_contact.py
+++ b/examples/python/contacts/delete_contact.py
@@ -1,0 +1,26 @@
+import requests
+
+API_KEY = '<your-api-key>'
+BASE_URL = 'https://api.maiagent.ai/api/v1/'
+
+CONTACT_ID = '<your-contact-id>'
+
+assert API_KEY != '<your-api-key>', 'Please set your API key'
+assert CONTACT_ID != '<your-contact-id>', 'Please set your contact id'
+
+
+def main():
+    headers = {'Authorization': f'Api-Key {API_KEY}'}
+
+    # 刪除聯絡人（軟刪除）
+    response = requests.delete(
+        url=f'{BASE_URL}contacts/{CONTACT_ID}/',
+        headers=headers,
+    )
+    response.raise_for_status()
+
+    print(f"聯絡人 {CONTACT_ID} 已刪除")
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/python/contacts/get_contact_conversations.py
+++ b/examples/python/contacts/get_contact_conversations.py
@@ -1,0 +1,54 @@
+import requests
+
+API_KEY = '<your-api-key>'
+BASE_URL = 'https://api.maiagent.ai/api/v1/'
+
+CONTACT_ID = '<your-contact-id>'
+
+assert API_KEY != '<your-api-key>', 'Please set your API key'
+assert CONTACT_ID != '<your-contact-id>', 'Please set your contact id'
+
+
+def main():
+    headers = {'Authorization': f'Api-Key {API_KEY}'}
+
+    # 取得聯絡人的所有對話
+    response = requests.get(
+        url=f'{BASE_URL}contacts/{CONTACT_ID}/conversations',
+        headers=headers,
+    )
+    response.raise_for_status()
+    data = response.json()
+
+    print(f"共 {data['count']} 筆對話")
+    for conversation in data['results']:
+        print(f"  - 對話 ID: {conversation['id']}")
+
+    # 也可以用關鍵字搜尋對話中的訊息
+    response = requests.get(
+        url=f'{BASE_URL}contacts/{CONTACT_ID}/conversations',
+        headers=headers,
+        params={
+            'keyword': '你好',
+            # 'inboxes': '<inbox-id>',  # 可依 inbox 篩選
+        },
+    )
+    response.raise_for_status()
+    data = response.json()
+
+    print(f"\n搜尋結果：共 {data['count']} 筆對話")
+
+    # 取得最新的一筆對話
+    response = requests.get(
+        url=f'{BASE_URL}contacts/{CONTACT_ID}/conversations/latest',
+        headers=headers,
+    )
+    if response.status_code == 200:
+        latest = response.json()
+        print(f"\n最新對話 ID: {latest['id']}")
+    elif response.status_code == 404:
+        print("\n該聯絡人尚無對話紀錄")
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/python/contacts/list_contacts.py
+++ b/examples/python/contacts/list_contacts.py
@@ -1,0 +1,71 @@
+import requests
+
+API_KEY = '<your-api-key>'
+BASE_URL = 'https://api.maiagent.ai/api/v1/'
+
+assert API_KEY != '<your-api-key>', 'Please set your API key'
+
+
+def main():
+    headers = {'Authorization': f'Api-Key {API_KEY}'}
+
+    # 列出所有聯絡人
+    response = requests.get(
+        url=f'{BASE_URL}contacts/',
+        headers=headers,
+    )
+    response.raise_for_status()
+    data = response.json()
+
+    print(f"共 {data['count']} 筆聯絡人")
+    for contact in data['results']:
+        print(f"  - {contact['name']} (ID: {contact['id']})")
+
+    # 使用篩選參數查詢
+    # query: 依名稱、ID 或 source_id 搜尋（模糊比對）
+    # inboxes: 依 inbox ID 篩選
+    response = requests.get(
+        url=f'{BASE_URL}contacts/',
+        headers=headers,
+        params={
+            'query': 'John',
+            'limit': 10,
+            'offset': 0,
+        },
+    )
+    response.raise_for_status()
+    data = response.json()
+
+    print(f"\n搜尋結果：共 {data['count']} 筆")
+    for contact in data['results']:
+        print(f"  - {contact['name']} (email: {contact.get('email', 'N/A')})")
+
+    """
+    回應格式：
+    {
+        "count": 100,
+        "next": "https://api.maiagent.ai/api/v1/contacts/?limit=20&offset=20",
+        "previous": null,
+        "results": [
+            {
+                "id": "contact-uuid",
+                "name": "John Doe",
+                "email": "john@example.com",
+                "phone_number": "+886912345678",
+                "avatar": "https://example.com/avatar.jpg",
+                "source_id": "external_id_123",
+                "inboxes": [
+                    {"id": "inbox-uuid", "name": "My Inbox"}
+                ],
+                "query_metadata": {"source": "web"},
+                "mcp_credentials": [],
+                "created_at": "2024-01-01T00:00:00Z",
+                "updated_at": "2024-01-01T00:00:00Z"
+            }
+        ]
+    }
+    """
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/python/contacts/update_contact.py
+++ b/examples/python/contacts/update_contact.py
@@ -1,0 +1,36 @@
+import requests
+
+API_KEY = '<your-api-key>'
+BASE_URL = 'https://api.maiagent.ai/api/v1/'
+
+CONTACT_ID = '<your-contact-id>'
+
+assert API_KEY != '<your-api-key>', 'Please set your API key'
+assert CONTACT_ID != '<your-contact-id>', 'Please set your contact id'
+
+
+def main():
+    headers = {'Authorization': f'Api-Key {API_KEY}'}
+
+    # 使用 PATCH 更新部分欄位
+    payload = {
+        'name': 'John Doe (Updated)',
+        'email': 'john.updated@example.com',
+    }
+
+    response = requests.patch(
+        url=f'{BASE_URL}contacts/{CONTACT_ID}/',
+        headers=headers,
+        json=payload,
+    )
+    response.raise_for_status()
+    contact = response.json()
+
+    print(f"聯絡人更新成功！")
+    print(f"  ID: {contact['id']}")
+    print(f"  名稱: {contact['name']}")
+    print(f"  Email: {contact.get('email', 'N/A')}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- 新增 `/api/contacts/` 的 API 文件說明（Python & C# 各一份 README）
- 新增 Python 和 C# 的 Contacts API 範例程式碼，涵蓋 CRUD、查詢對話紀錄、群發訊息等操作
- 更新 Python 和 C# 的主 README，加入 contacts 資料夾連結

## 新增檔案
| 範例 | Python | C# |
|------|--------|----|
| 列出聯絡人 | `list_contacts.py` | `list_contacts.cs` |
| 建立聯絡人 | `create_contact.py` | `create_contact.cs` |
| 更新聯絡人 | `update_contact.py` | `update_contact.cs` |
| 刪除聯絡人 | `delete_contact.py` | `delete_contact.cs` |
| 查詢對話紀錄 | `get_contact_conversations.py` | `get_contact_conversations.cs` |
| 群發訊息 | `broadcast_message.py` | `broadcast_message.cs` |

## Test plan
- [ ] 確認 README 中的 API 端點與欄位說明正確
- [ ] 確認範例程式碼可正常執行
- [ ] 確認 Python / C# 主 README 連結正確

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and example-code only; no production logic changes or security-sensitive behavior modified.
> 
> **Overview**
> Adds a new `contacts/` example suite for both Python and C# documenting and demonstrating the Contacts API, including contact CRUD, fetching a contact’s conversations (including latest/keyword search), and broadcasting messages.
> 
> Updates the top-level `examples/python/README.md` and `examples/csharp/README.md` to link to the new Contacts examples and list the new sample files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65451f7a228f6909cb96d7105b61d91438ab8b78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->